### PR TITLE
Fork post-processors before loading the language model.

### DIFF
--- a/kaldigstserver/worker.py
+++ b/kaldigstserver/worker.py
@@ -330,6 +330,15 @@ def main():
     if "logging" in conf:
         logging.config.dictConfig(conf["logging"])
 
+    # fork off the post-processors before we load the model into memory
+    post_processor = None
+    if "post-processor" in conf:
+        post_processor = Popen(conf["post-processor"], shell=True, stdin=PIPE, stdout=PIPE)
+
+    full_post_processor = None
+    if "full-post-processor" in conf:
+        full_post_processor = Popen(conf["full-post-processor"], shell=True, stdin=PIPE, stdout=PIPE)
+
     global USE_NNET2
     USE_NNET2 = conf.get("use-nnet2", False)
 
@@ -339,14 +348,6 @@ def main():
         decoder_pipeline = DecoderPipeline2(conf)
     else:
         decoder_pipeline = DecoderPipeline(conf)
-
-    post_processor = None
-    if "post-processor" in conf:
-        post_processor = Popen(conf["post-processor"], shell=True, stdin=PIPE, stdout=PIPE)
-
-    full_post_processor = None
-    if "full-post-processor" in conf:
-        full_post_processor = Popen(conf["full-post-processor"], shell=True, stdin=PIPE, stdout=PIPE)
 
 
     loop = GObject.MainLoop()


### PR DESCRIPTION
This prevents out-of-memory errors when the system's RAM is nearly full. With this commit, I can launch a worker which requires 2.4GB of RAM on a server with 2.6GB free; otherwise, I get an out of memory error. Once the LM has been loaded into memory, the footprint is huge so a fork is expensive.