### PR TITLE
during full post processing, flush full_post_processor's stdin

### DIFF
--- a/kaldigstserver/worker.py
+++ b/kaldigstserver/worker.py
@@ -287,7 +287,7 @@ class ServerWebsocket(WebSocketClient):
     def post_process_full(self, full_result):
         if self.full_post_processor:
             self.full_post_processor.stdin.write("%s\n\n" % json.dumps(full_result))
-            self.post_processor.stdin.flush()
+            self.full_post_processor.stdin.flush()
             lines = []
             while True:
                 l = self.full_post_processor.stdout.readline()


### PR DESCRIPTION
If there is no post_processor defined in config, but there is a full_post_processor - the worker attempts to flush the post_processor's stdin instead of the full_post_processor's, resulting in "AttributeError: 'NoneType' object has no attribute 'stdin'"