### PR TITLE
Update worker.py

### DIFF
--- a/kaldigstserver/worker.py
+++ b/kaldigstserver/worker.py
@@ -69,7 +69,7 @@ class ServerWebsocket(WebSocketClient):
 
     def guard_timeout(self):
         global SILENCE_TIMEOUT
-        while self.state in [self.STATE_CONNECTED, self.STATE_INITIALIZED, self.STATE_PROCESSING]:
+        while self.state in [self.STATE_EOS_RECEIVED, self.STATE_CONNECTED, self.STATE_INITIALIZED, self.STATE_PROCESSING]:
             if time.time() - self.last_decoder_message > SILENCE_TIMEOUT:
                 logger.warning("%s: More than %d seconds from last decoder hypothesis update, cancelling" % (self.request_id, SILENCE_TIMEOUT))
                 self.finish_request()


### PR DESCRIPTION
I noticed that in my usage, a worker could hang forever after running the following statement, the timeout guard is not in effective, I did applied the changes and so far I didn't have this issue any more.
    self.decoder_pipeline.end_request()
    self.state = self.STATE_EOS_RECEIVED