### PR TITLE
support nnet-mode

### DIFF
--- a/kaldigstserver/decoder2.py
+++ b/kaldigstserver/decoder2.py
@@ -52,6 +52,11 @@ class DecoderPipeline2(object):
         if "use-threaded-decoder" in conf["decoder"]:
             self.asr.set_property("use-threaded-decoder", conf["decoder"]["use-threaded-decoder"])
 
+        decoder_config = conf.get("decoder", {})
+        if 'nnet-mode' in decoder_config:
+          self.asr.set_property('nnet-mode', decoder_config['nnet-mode'])
+          del decoder_config['nnet-mode']
+
         for (key, val) in conf.get("decoder", {}).iteritems():
             if key != "use-threaded-decoder":
                 logger.info("Setting decoder property: %s = %s" % (key, val))

--- a/kaldigstserver/decoder2.py
+++ b/kaldigstserver/decoder2.py
@@ -54,10 +54,11 @@ class DecoderPipeline2(object):
 
         decoder_config = conf.get("decoder", {})
         if 'nnet-mode' in decoder_config:
+          logger.info(("Setting decoder property: %s = %s" % ('nnet-mode', decoder_config['nnet-mode']))
           self.asr.set_property('nnet-mode', decoder_config['nnet-mode'])
           del decoder_config['nnet-mode']
 
-        for (key, val) in conf.get("decoder", {}).iteritems():
+        for (key, val) in decoder_config.iteritems():
             if key != "use-threaded-decoder":
                 logger.info("Setting decoder property: %s = %s" % (key, val))
                 self.asr.set_property(key, val)


### PR DESCRIPTION
this is related to: https://github.com/alumae/gst-kaldi-nnet2-online/pull/42
To correctly support nnet-mode introduced in referred pull request, it has to be set before other paramters (because different nnet-mode will use different decoder, different configuration needs to be hooked to gst properties correctly). this pull request will find nnet-mode in config and use it before going through other items in config.