### PR TITLE
added SSL support for server

### DIFF
--- a/kaldigstserver/master_server.py
+++ b/kaldigstserver/master_server.py
@@ -336,13 +336,13 @@ def main():
       
     tornado.options.parse_command_line()
     app = Application()
-    ssl_options = None
+    app.listen(options.port)
     if options.certfile and options.keyfile:
         ssl_options = {
           "certfile": options.certfile,
           "keyfile": options.keyfile,
         }
-    app.listen(options.port, ssl_options=ssl_options)
+        app.listen(options.port+1, ssl_options=ssl_options)
 
     tornado.ioloop.IOLoop.instance().start()
 

--- a/kaldigstserver/master_server.py
+++ b/kaldigstserver/master_server.py
@@ -329,11 +329,21 @@ class DecoderSocketHandler(tornado.websocket.WebSocketHandler):
 def main():
     logging.basicConfig(level=logging.DEBUG, format="%(levelname)8s %(asctime)s %(message)s ")
     logging.debug('Starting up server')
-    from tornado.options import options
+    from tornado.options import define, options
 
+    define("certfile", default="", help="certificate file for secured SSL connection")
+    define("keyfile", default="", help="key file for secured SSL connection")
+      
     tornado.options.parse_command_line()
     app = Application()
-    app.listen(options.port)
+    ssl_options = None
+    if options.certfile and options.keyfile:
+        ssl_options = {
+          "certfile": options.certfile,
+          "keyfile": options.keyfile,
+        }
+    app.listen(options.port, ssl_options=ssl_options)
+
     tornado.ioloop.IOLoop.instance().start()
 
 


### PR DESCRIPTION
With this change, the server will listen to `port` and `port+1` if `--certfile` and `--keyfile` are used. Normal `ws://` connection should use port `port`, secured websocket `wss://` will use port `port+1`. This will get around the problem Chrome prevents user to send audio data to non-secure server.

Usage:
`master_server.py --certfile=fullchain.pem --keyfile=privkey.pem`