### PR TITLE
Serve kaljurand.github.io/dictate.js over https

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ suitable for the application.
 Client software
 ---------------
 
-Javascript client is available here: http://kaljurand.github.io/dictate.js
+Javascript client is available here: https://kaljurand.github.io/dictate.js
 
 Citing
 ------


### PR DESCRIPTION
otherwise the demos linked from this page use http and thus do not work in Google Chrome.