### PR TITLE
Add check for existence of `self.outdir`

### DIFF
--- a/kaldigstserver/decoder.py
+++ b/kaldigstserver/decoder.py
@@ -24,10 +24,11 @@ class DecoderPipeline(object):
         self.use_cutter = conf.get("use-vad", False)
         self.create_pipeline(conf)
         self.outdir = conf.get("out-dir", None)
-        if not os.path.exists(self.outdir):
-            os.mkdir(self.outdir)
-        elif not os.path.isdir(self.outdir):
-            raise Exception("Output directory %s already exists as a file" % self.outdir)
+        if self.outdir:
+            if not os.path.exists(self.outdir):
+                os.mkdir(self.outdir)
+            elif not os.path.isdir(self.outdir):
+                raise Exception("Output directory %s already exists as a file" % self.outdir)
 
         self.word_handler = None
         self.eos_handler = None

--- a/kaldigstserver/decoder2.py
+++ b/kaldigstserver/decoder2.py
@@ -23,10 +23,11 @@ class DecoderPipeline2(object):
         logger.info("Creating decoder using conf: %s" % conf)
         self.create_pipeline(conf)
         self.outdir = conf.get("out-dir", None)
-        if not os.path.exists(self.outdir):
-            os.makedirs(self.outdir)
-        elif not os.path.isdir(self.outdir):
-            raise Exception("Output directory %s already exists as a file" % self.outdir)
+        if self.outdir:
+            if not os.path.exists(self.outdir):
+                os.makedirs(self.outdir)
+            elif not os.path.isdir(self.outdir):
+                raise Exception("Output directory %s already exists as a file" % self.outdir)
 
         self.result_handler = None
         self.full_result_handler = None


### PR DESCRIPTION
Fixes error in `os.path.exists` function call when `self.outdir` is `None`