### PR TITLE
improve error message for unsuccessful loading of kaldinnet2onlinedecoder

### DIFF
--- a/kaldigstserver/decoder.py
+++ b/kaldigstserver/decoder.py
@@ -51,14 +51,14 @@ class DecoderPipeline(object):
         self.fakesink = Gst.ElementFactory.make("fakesink", "fakesink")
 
         if not self.asr:
-            print >> sys.stderr, "ERROR: Couldn't create the kaldinnet2onlinedecoder element!"
+            print >> sys.stderr, "ERROR: Couldn't create the onlinegmmdecodefaster element!"
             gst_plugin_path = os.environ.get("GST_PLUGIN_PATH")
             if gst_plugin_path:
                 print >> sys.stderr, \
-                    "Couldn't find kaldinnet2onlinedecoder element at %s. " \
+                    "Couldn't find onlinegmmdecodefaster element at %s. " \
                     "If it's not the right path, try to set GST_PLUGIN_PATH to the right one, and retry. " \
                     "You can also try to run the following command: " \
-                    "'GST_PLUGIN_PATH=%s gst-inspect-1.0 kaldinnet2onlinedecoder'." \
+                    "'GST_PLUGIN_PATH=%s gst-inspect-1.0 onlinegmmdecodefaster'." \
                     % (gst_plugin_path, gst_plugin_path)
             else:
                 print >> sys.stderr, \
@@ -194,7 +194,7 @@ class DecoderPipeline(object):
             self.filesink.set_property('location', "%s/%s.raw" % (self.outdir, id))
             self.filesink.set_state(Gst.State.PLAYING)
 
-        #self.filesink.set_state(Gst.State.PLAYING)        
+        #self.filesink.set_state(Gst.State.PLAYING)
         #self.decodebin.set_state(Gst.State.PLAYING)
         self.pipeline.set_state(Gst.State.PLAYING)
         self.filesink.set_state(Gst.State.PLAYING)

--- a/kaldigstserver/decoder.py
+++ b/kaldigstserver/decoder.py
@@ -50,6 +50,22 @@ class DecoderPipeline(object):
         self.asr = Gst.ElementFactory.make("onlinegmmdecodefaster", "asr")
         self.fakesink = Gst.ElementFactory.make("fakesink", "fakesink")
 
+        if not self.asr:
+            print >> sys.stderr, "ERROR: Couldn't create the kaldinnet2onlinedecoder element!"
+            gst_plugin_path = os.environ.get("GST_PLUGIN_PATH")
+            if gst_plugin_path:
+                print >> sys.stderr, \
+                    "Couldn't find kaldinnet2onlinedecoder element at %s. " \
+                    "If it's not the right path, try to set GST_PLUGIN_PATH to the right one, and retry. " \
+                    "You can also try to run the following command: " \
+                    "'GST_PLUGIN_PATH=%s gst-inspect-1.0 kaldinnet2onlinedecoder'." \
+                    % (gst_plugin_path, gst_plugin_path)
+            else:
+                print >> sys.stderr, \
+                    "The environment variable GST_PLUGIN_PATH wasn't set or it's empty. " \
+                    "Try to set GST_PLUGIN_PATH environment variable, and retry."
+            sys.exit(-1);
+
         for (key, val) in conf.get("decoder", {}).iteritems():
             logger.info("Setting decoder property: %s = %s" % (key, val))
             self.asr.set_property(key, val)

--- a/kaldigstserver/decoder2.py
+++ b/kaldigstserver/decoder2.py
@@ -50,6 +50,22 @@ class DecoderPipeline2(object):
         self.asr = Gst.ElementFactory.make("kaldinnet2onlinedecoder", "asr")
         self.fakesink = Gst.ElementFactory.make("fakesink", "fakesink")
 
+        if not self.asr:
+            print >> sys.stderr, "ERROR: Couldn't create the kaldinnet2onlinedecoder element!"
+            gst_plugin_path = os.environ.get("GST_PLUGIN_PATH")
+            if gst_plugin_path:
+                print >> sys.stderr, \
+                    "Couldn't find kaldinnet2onlinedecoder element at %s. " \
+                    "If it's not the right path, try to set GST_PLUGIN_PATH to the right one, and retry. " \
+                    "You can also try to run the following command: " \
+                    "'GST_PLUGIN_PATH=%s gst-inspect-1.0 kaldinnet2onlinedecoder'." \
+                    % (gst_plugin_path, gst_plugin_path)
+            else:
+                print >> sys.stderr, \
+                    "The environment variable GST_PLUGIN_PATH wasn't set or it's empty. " \
+                    "Try to set GST_PLUGIN_PATH environment variable, and retry."
+            sys.exit(-1);
+
         # This needs to be set first
         if "use-threaded-decoder" in conf["decoder"]:
             self.asr.set_property("use-threaded-decoder", conf["decoder"]["use-threaded-decoder"])


### PR DESCRIPTION
Today, when there is a problem with the kaldinnet2onlinedecoder plugin,
user will see the following error:
AttributeError: 'NoneType' object has no attribute 'set_property'
Instead of that, we want to point the user to the root cause of the problem.