### PR TITLE
update chinese model

### DIFF
--- a/test/models/download-multi_cn-nnet3.sh
+++ b/test/models/download-multi_cn-nnet3.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 BASE_URL=http://kaldi-asr.org/models/11/
-MODEL=0011_multi_cn_chain_sp_online.tar.gz
+MODEL=0011_multi_cn_chain_sp_online_v2.tar.gz
 
 modeldir=`dirname $0`/chinese
 


### PR DESCRIPTION
This is reagarding a recent fix on the Chinese model training recipe, i.e. kaldi-asr/kaldi#3686
This model works properly with the sample config yaml.