### PR TITLE
fix post_processor block issue

### DIFF
--- a/kaldigstserver/worker.py
+++ b/kaldigstserver/worker.py
@@ -311,7 +311,7 @@ class ServerWebsocket(WebSocketClient):
             if blocking:
                 timeout=None
             else:
-                timeout=0.0
+                timeout=0.001
             try:
                 with (yield self.post_processor_lock.acquire(timeout)):
                     result = []


### PR DESCRIPTION
Acquiring tornado.locks.Lock with timeout=0.0 causes block.
https://github.com/tornadoweb/tornado/blob/v4.5.3/tornado/locks.py#L389